### PR TITLE
Update project to Android Gradle Plugin 8.4.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.2.2" apply false
+    id("com.android.application") version "8.4.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- bump the Android Gradle Plugin to version 8.4.1 in the root build script
- update the Gradle wrapper distribution to 8.6 to satisfy the new plugin requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbfb690338832b9f77dbf75ac04a3f