### PR TITLE
Add Material Components dependency for Material 3 XML themes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,13 +54,17 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
 
+    // Compose
     implementation("androidx.activity:activity-compose:1.9.2")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
 
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    // Material Components (XML Material 3 themes)
+    implementation("com.google.android.material:material:1.12.0")
+
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.4.1" apply false
+    id("com.android.application") version "8.5.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
 }


### PR DESCRIPTION
## Summary
- add Material Components dependency required for XML-based Material 3 themes while keeping existing Compose setup
- update the Android Gradle Plugin to version 8.5.0 to keep the project on a current toolchain

## Testing
- Not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_b_68dc0619c228832ba133e98fb2bf66c6