### PR TITLE
Raise minSdk to 26 and ensure vector adaptive launcher icon

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.apphandroll"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,10 +4,11 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Un ícono simple (círculo + letra H) -->
+    <!-- círculo blanco -->
     <path
         android:fillColor="#FFFFFF"
         android:pathData="M54,10a44,44 0,1 1,0,88a44,44 0,1 1,0,-88z"/>
+    <!-- letra H negra -->
     <path
         android:fillColor="#000000"
         android:pathData="M42,30h8v18h8V30h8v48h-8V54h-8v24h-8z"/>


### PR DESCRIPTION
## Summary
- raise the Android minSdk version to 26 so adaptive icons do not need legacy fallbacks
- ensure the launcher foreground vector uses the desired design annotations

## Testing
- ⚠️ `./gradlew assembleDebug` *(fails: bash reported "No such file or directory" because the Gradle wrapper script is absent in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68dc0ef070a4832b9f47dd85cc70b8b6