### PR TITLE
Use drawable vector launcher icons

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@drawable/ic_launcher_foreground"
         android:label="AppHandroll"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppHandroll">
         <activity

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,12 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Light scheme -->
-    <color name="md_theme_light_primaryContainer">#FFE0B2</color>
-    <color name="md_theme_light_onPrimaryContainer">#3A2500</color>
-
-    <!-- Dark scheme -->
-    <color name="md_theme_dark_primaryContainer">#5A3A00</color>
-    <color name="md_theme_dark_onPrimaryContainer">#FFDDB3</color>
-
     <color name="ic_launcher_background">#FF6F00</color>
 </resources>


### PR DESCRIPTION
## Summary
- point the application icon to the vector drawable foreground asset
- trim the colors resource file to define the launcher background color only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc13060e7c832bb9e6e3c52be90ce5