### PR TITLE
Add safeguards against binary resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@
 .DS_Store
 /build/
 app/build/
+
+# Evitar que recursos binarios se agreguen al repositorio
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.webp
+**/*.ico
+**/*.aab
+**/*.apk
+**/*.keystore
+**/*.jar

--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Aplicación Android construida con Kotlin y Jetpack Compose que permite crear pe
 1. Clona este repositorio.
 2. Abre el proyecto en Android Studio.
 3. Sincroniza Gradle y ejecuta la app en un dispositivo o emulador Android (API 24+).
+
+## Política sobre archivos binarios
+Este repositorio no admite la inclusión de archivos binarios en las solicitudes de extracción.
+Utiliza recursos vectoriales (XML/Compose) o genera el contenido en tiempo de ejecución.
+Se agregó una verificación automática en los tests para asegurar que `src/main/res` permanezca libre de binarios.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,4 +42,6 @@ dependencies {
 
     // Temas XML de Material 3
     implementation("com.google.android.material:material:1.12.0")
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/test/java/com/example/apphandroll/NoBinaryResourcesTest.kt
+++ b/app/src/test/java/com/example/apphandroll/NoBinaryResourcesTest.kt
@@ -1,0 +1,46 @@
+package com.example.apphandroll
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.BufferedInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class NoBinaryResourcesTest {
+    @Test
+    fun `resources directory contains only text files`() {
+        val resourcesDir = Paths.get("src/main/res")
+        require(Files.exists(resourcesDir)) { "No se encontró el directorio de recursos: $resourcesDir" }
+
+        val binaryFiles = mutableListOf<String>()
+        Files.walk(resourcesDir).use { paths ->
+            paths.filter { Files.isRegularFile(it) }
+                .forEach { path ->
+                    if (containsBinaryData(path)) {
+                        binaryFiles += resourcesDir.relativize(path).toString()
+                    }
+                }
+        }
+
+        assertTrue(
+            "Se detectaron archivos binarios en src/main/res: ${binaryFiles.joinToString()}",
+            binaryFiles.isEmpty()
+        )
+    }
+
+    private fun containsBinaryData(path: Path): Boolean {
+        BufferedInputStream(Files.newInputStream(path)).use { input ->
+            val buffer = ByteArray(4096)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) return false
+                for (i in 0 until read) {
+                    if (buffer[i] == 0.toByte()) {
+                        return true
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document the repository policy forbidding binary assets and expand .gitignore to cover common binary types
- add a unit test that scans src/main/res to ensure only text resources are committed
- include the JUnit dependency required to run the new verification test

## Testing
- `./gradlew test` *(fails: wrapper script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68dc29cdd2cc832bb2cced3573a117f8