### PR TITLE
Fix launcher icon references

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@drawable/ic_launcher_foreground"
         android:label="AppHandroll"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppHandroll">
         <activity


### PR DESCRIPTION
## Summary
- update the manifest to use the existing drawable launcher asset instead of missing mipmap resources
- remove the round icon reference that pointed at absent mipmap resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc2d091488832b919eb1b41e472aff