### PR TITLE
Fix launcher icon resources

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
-        android:icon="@drawable/ic_launcher_foreground"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="AppHandroll"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppHandroll">

--- a/app/src/main/res/mipmap/ic_launcher.xml
+++ b/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-  <background android:drawable="@drawable/ic_launcher_background"/>
-  <foreground android:drawable="@drawable/ic_launcher_foreground"/>
-</adaptive-icon>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF6F00"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M30,22a18,18 0,1 1,48,0v64h-48z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M46,38h8v18h8V38h8v40h-8V56h-8v22h-8z" />
+</vector>

--- a/app/src/main/res/mipmap/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-  <background android:drawable="@drawable/ic_launcher_background"/>
-  <foreground android:drawable="@drawable/ic_launcher_foreground"/>
-</adaptive-icon>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF6F00"
+        android:pathData="M54,4a50,50 0,1 1,0,100a50,50 0,1 1,0,-100z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M34,22a20,20 0,1 1,40,0v64h-40z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M46,38h8v18h8V38h8v40h-8V56h-8v22h-8z" />
+</vector>


### PR DESCRIPTION
## Summary
- point the application manifest at mipmap-based launcher resources
- replace the missing adaptive launcher icons with vector drawables that can be packaged with the project

## Testing
- not run (wrapper script `./gradlew` is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_b_68dc2e711148832b9fb95031125e7b73