### PR TITLE
fix(theme): add missing Material 3 container colors and wire them in themes

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.AppHandroll" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/md_theme_dark_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>
         <item name="colorOnPrimaryContainer">@color/md_theme_dark_onPrimaryContainer</item>
     </style>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <color name="ic_launcher_background">#FF6F00</color>
+
+  <!-- Light -->
+  <color name="md_theme_light_primary">#6750A4</color>
+  <color name="md_theme_light_onPrimary">#FFFFFF</color>
+  <color name="md_theme_light_primaryContainer">#EADDFF</color>
+  <color name="md_theme_light_onPrimaryContainer">#21005D</color>
+
+  <!-- Dark -->
+  <color name="md_theme_dark_primary">#D0BCFF</color>
+  <color name="md_theme_dark_onPrimary">#381E72</color>
+  <color name="md_theme_dark_primaryContainer">#4F378B</color>
+  <color name="md_theme_dark_onPrimaryContainer">#EADDFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.AppHandroll" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
         <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
     </style>


### PR DESCRIPTION
## Summary
- add the missing Material 3 light and dark color resources for primary/onPrimary containers
- reference the new colors from the existing light and dark app themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc3a45f600832b99d8965d1949ca70