### PR TITLE
build: align Java/Kotlin to JVM 17 (fix target mismatch)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,17 @@ android {
 
     buildFeatures { compose = true }
     composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- align the Android compile options to Java 17 to resolve JVM target mismatch
- configure Kotlin JVM target and toolchain to 17 for compatibility

## Testing
- ⚠️ ./gradlew :app:compileDebugKotlin (wrapper script not present in repository)


------
https://chatgpt.com/codex/tasks/task_b_68dc3dd356d4832ba741988c5ee3df10