### PR TITLE
fix(compose): regularizar uso de weight (scope Row/Column + imports)

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -445,20 +444,18 @@ fun CartScreen(
             if (cartItems.isEmpty()) {
                 Text(text = "Carrito vacío", style = MaterialTheme.typography.bodyLarge)
             } else {
-                Box(
-                    modifier = Modifier.weight(1f, fill = false)
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        items(cartItems, key = { it.id }) { item ->
-                            CartItemRow(
-                                item = item,
-                                onEdit = { onEditItem(item) },
-                                onDelete = { onRemoveItem(item.id) }
-                            )
-                        }
+                    items(cartItems, key = { it.id }) { item ->
+                        CartItemRow(
+                            item = item,
+                            onEdit = { onEditItem(item) },
+                            onDelete = { onRemoveItem(item.id) }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- usar Modifier.weight directamente en el LazyColumn del carrito dentro del ColumnScope
- limpiar el layout eliminando el contenedor Box innecesario y sus imports asociados

## Testing
- ⚠️ `./gradlew :app:compileDebugKotlin` (no disponible en el repositorio)


------
https://chatgpt.com/codex/tasks/task_b_68dd8a9aa52c832b9401861c2c7647b8