### PR TITLE
fix(compose): usar Modifier.weight dentro de Row/Column y limpiar imports (evitar API interna)

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape


### PR DESCRIPTION
## Summary
- eliminar el import interno de `Modifier.weight`
- asegurar que el único uso de `Modifier.weight` permanezca dentro del alcance de `Column`

## Testing
- no se ejecutaron pruebas (no solicitado)

------
https://chatgpt.com/codex/tasks/task_b_68dd8da7d750832bbba3b2cf2c113f2a