### PR TITLE
Update Handroll customization flow

### DIFF
--- a/app/src/main/java/com/example/apphandroll/ShopViewModel.kt
+++ b/app/src/main/java/com/example/apphandroll/ShopViewModel.kt
@@ -15,13 +15,13 @@ class ShopViewModel : ViewModel() {
             id = "handroll",
             name = "Handroll",
             basePrice = 3500,
-            baseIncludedDescription = "Elige tu proteína favorita, acompáñala con una base cremosa y un vegetal fresco. Si quieres más, puedes agregar proteínas o bases extra por $1.000 y vegetales extra por $500.",
+            baseIncludedDescription = "Incluye hasta 1 proteína, 1 base y 1 vegetal sin costo extra. Proteína o base extra +$1.000, vegetal extra +$500.",
             optionalIngredients = emptyList(),
             ingredientCategories = listOf(
                 IngredientCategory(
                     id = "handroll_proteina",
-                    title = "Proteína",
-                    description = "Selecciona al menos 1 proteína para tu handroll. Cada proteína adicional suma $1.000.",
+                    title = "Proteínas",
+                    description = "Incluye hasta 1 proteína sin costo. Cada proteína adicional suma $1.000.",
                     options = listOf(
                         IngredientOption(id = "handroll_proteina_pollo", name = "Pollo"),
                         IngredientOption(id = "handroll_proteina_camaron", name = "Camarón"),
@@ -35,8 +35,8 @@ class ShopViewModel : ViewModel() {
                 ),
                 IngredientCategory(
                     id = "handroll_base",
-                    title = "Base cremosa",
-                    description = "Incluye 1 base cremosa. Cada base extra suma $1.000.",
+                    title = "Bases",
+                    description = "Incluye hasta 1 base sin costo. Cada base adicional suma $1.000.",
                     options = listOf(
                         IngredientOption(id = "handroll_base_queso", name = "Queso"),
                         IngredientOption(id = "handroll_base_palta", name = "Palta")
@@ -46,8 +46,8 @@ class ShopViewModel : ViewModel() {
                 ),
                 IngredientCategory(
                     id = "handroll_vegetal",
-                    title = "Vegetal fresco",
-                    description = "Escoge 1 vegetal para dar frescura. Cada vegetal adicional suma $500.",
+                    title = "Vegetales",
+                    description = "Incluye hasta 1 vegetal sin costo. Cada vegetal adicional suma $500.",
                     options = listOf(
                         IngredientOption(id = "handroll_vegetal_cebollin", name = "Cebollín"),
                         IngredientOption(id = "handroll_vegetal_ciboulette", name = "Ciboulette"),


### PR DESCRIPTION
## Summary
- refresh the Handroll catalog metadata to use the new category names and pricing copy
- update the ingredient selector to allow any category mix, enforce a minimum of one item, and label included vs extra picks
- surface live pricing feedback for the Handroll, including counters and extra charges per category

## Testing
- ./gradlew test *(fails: wrapper script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68dead063adc832ba273dbd0b498155e