### PR TITLE
Add repository-wide binary file checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Aplicación Android construida con Kotlin y Jetpack Compose que permite crear pe
 ## Política sobre archivos binarios
 Este repositorio no admite la inclusión de archivos binarios en las solicitudes de extracción.
 Utiliza recursos vectoriales (XML/Compose) o genera el contenido en tiempo de ejecución.
-Se agregó una verificación automática en los tests para asegurar que `src/main/res` permanezca libre de binarios.
+Se agregaron verificaciones automáticas en los tests para asegurar que `src/main/res` y el resto del repositorio permanezcan libres de binarios.

--- a/app/src/test/java/com/example/apphandroll/BinaryFileDetector.kt
+++ b/app/src/test/java/com/example/apphandroll/BinaryFileDetector.kt
@@ -1,0 +1,56 @@
+package com.example.apphandroll
+
+import java.io.BufferedInputStream
+import java.nio.ByteBuffer
+import java.nio.CharBuffer
+import java.nio.charset.CharacterCodingException
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+object BinaryFileDetector {
+    private const val BUFFER_SIZE = 4096
+
+    fun containsBinaryData(path: Path): Boolean {
+        BufferedInputStream(Files.newInputStream(path)).use { input ->
+            val decoder = StandardCharsets.UTF_8.newDecoder().apply {
+                onMalformedInput(CodingErrorAction.REPORT)
+                onUnmappableCharacter(CodingErrorAction.REPORT)
+            }
+            val byteBuffer = ByteBuffer.allocate(BUFFER_SIZE)
+            val charBuffer = CharBuffer.allocate(BUFFER_SIZE)
+            val buffer = ByteArray(BUFFER_SIZE)
+
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+
+                for (index in 0 until read) {
+                    if (buffer[index] == 0.toByte()) {
+                        return true
+                    }
+                }
+
+                byteBuffer.clear()
+                byteBuffer.put(buffer, 0, read)
+                byteBuffer.flip()
+
+                try {
+                    decoder.decode(byteBuffer, charBuffer, false)
+                } catch (error: CharacterCodingException) {
+                    return true
+                } finally {
+                    charBuffer.clear()
+                }
+            }
+
+            return try {
+                decoder.flush(charBuffer)
+                false
+            } catch (error: CharacterCodingException) {
+                true
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/apphandroll/NoBinaryFilesInRepoTest.kt
+++ b/app/src/test/java/com/example/apphandroll/NoBinaryFilesInRepoTest.kt
@@ -1,0 +1,60 @@
+package com.example.apphandroll
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class NoBinaryFilesInRepoTest {
+
+    @Test
+    fun `el repositorio no contiene archivos binarios no admitidos`() {
+        val repoRoot = locateRepositoryRoot()
+        val binaryFiles = mutableListOf<String>()
+
+        Files.walk(repoRoot).use { paths ->
+            paths.filter { Files.isRegularFile(it) && !shouldIgnore(it, repoRoot) }
+                .forEach { path ->
+                    if (BinaryFileDetector.containsBinaryData(path)) {
+                        binaryFiles += repoRoot.relativize(path).toString()
+                    }
+                }
+        }
+
+        assertTrue(
+            "Se detectaron archivos binarios en el repositorio: ${binaryFiles.joinToString()}",
+            binaryFiles.isEmpty()
+        )
+    }
+
+    private fun locateRepositoryRoot(): Path {
+        var current = Paths.get("").toAbsolutePath()
+
+        while (true) {
+            if (Files.exists(current.resolve(".git"))) {
+                return current
+            }
+
+            current = current.parent ?: break
+        }
+
+        error("No se encontró el directorio .git partiendo desde ${Paths.get("").toAbsolutePath()}")
+    }
+
+    private fun shouldIgnore(path: Path, repoRoot: Path): Boolean {
+        val relative = repoRoot.relativize(path).toString().replace('\\', '/')
+        if (relative.isEmpty()) return true
+
+        val segments = relative.split('/')
+        if (segments.any { it == ".git" || it == "build" || it == ".gradle" || it == ".idea" }) {
+            return true
+        }
+
+        if (relative == "gradle/wrapper/gradle-wrapper.jar") {
+            return true
+        }
+
+        return false
+    }
+}

--- a/app/src/test/java/com/example/apphandroll/NoBinaryResourcesTest.kt
+++ b/app/src/test/java/com/example/apphandroll/NoBinaryResourcesTest.kt
@@ -2,9 +2,7 @@ package com.example.apphandroll
 
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.BufferedInputStream
 import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.Paths
 
 class NoBinaryResourcesTest {
@@ -17,7 +15,7 @@ class NoBinaryResourcesTest {
         Files.walk(resourcesDir).use { paths ->
             paths.filter { Files.isRegularFile(it) }
                 .forEach { path ->
-                    if (containsBinaryData(path)) {
+                    if (BinaryFileDetector.containsBinaryData(path)) {
                         binaryFiles += resourcesDir.relativize(path).toString()
                     }
                 }
@@ -27,20 +25,5 @@ class NoBinaryResourcesTest {
             "Se detectaron archivos binarios en src/main/res: ${binaryFiles.joinToString()}",
             binaryFiles.isEmpty()
         )
-    }
-
-    private fun containsBinaryData(path: Path): Boolean {
-        BufferedInputStream(Files.newInputStream(path)).use { input ->
-            val buffer = ByteArray(4096)
-            while (true) {
-                val read = input.read(buffer)
-                if (read == -1) return false
-                for (i in 0 until read) {
-                    if (buffer[i] == 0.toByte()) {
-                        return true
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- extract binary detection logic into a reusable `BinaryFileDetector`
- add a repository-wide unit test that scans tracked files for binary content
- document the new automated guardrails in the README

## Testing
- not run (Gradle wrapper script is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_b_68deb84b57e8832bbed59cc240af29be