### PR TITLE
feat: customize vegetarian sushipleto ingredient picker

### DIFF
--- a/app/src/main/java/com/example/apphandroll/ShopViewModel.kt
+++ b/app/src/main/java/com/example/apphandroll/ShopViewModel.kt
@@ -86,7 +86,42 @@ class ShopViewModel : ViewModel() {
             name = "Sushipleto Vegetariano",
             basePrice = 4500,
             baseIncludedDescription = "Deliciosa combinación de champiñón o palmito, queso, palta y un toque de cebollín o ciboulette.",
-            optionalIngredients = emptyList()
+            optionalIngredients = emptyList(),
+            ingredientCategories = listOf(
+                IngredientCategory(
+                    id = "sushipleto_vegetariano_base",
+                    title = "Base",
+                    description = "Incluye 1 base sin costo. Agregar otra base suma $1.000.",
+                    options = listOf(
+                        IngredientOption(id = "sushipleto_vegetariano_base_champinon", name = "Champiñón"),
+                        IngredientOption(id = "sushipleto_vegetariano_base_palmito", name = "Palmito")
+                    ),
+                    includedCount = 1,
+                    extraPrice = 1000
+                ),
+                IngredientCategory(
+                    id = "sushipleto_vegetariano_a_eleccion_cremoso",
+                    title = "A elección (Queso/Palta)",
+                    description = "Cada opción agrega un extra de $1.000.",
+                    options = listOf(
+                        IngredientOption(id = "sushipleto_vegetariano_eleccion_queso", name = "Queso"),
+                        IngredientOption(id = "sushipleto_vegetariano_eleccion_palta", name = "Palta")
+                    ),
+                    includedCount = 0,
+                    extraPrice = 1000
+                ),
+                IngredientCategory(
+                    id = "sushipleto_vegetariano_a_eleccion_vegetal",
+                    title = "A elección (Cebollín/Ciboulette)",
+                    description = "Cada opción agrega un extra de $500.",
+                    options = listOf(
+                        IngredientOption(id = "sushipleto_vegetariano_eleccion_cebollin", name = "Cebollín"),
+                        IngredientOption(id = "sushipleto_vegetariano_eleccion_ciboulette", name = "Ciboulette")
+                    ),
+                    includedCount = 0,
+                    extraPrice = 500
+                )
+            )
         ),
         Product(
             id = "gohan",


### PR DESCRIPTION
## Summary
- configure the Sushipleto Vegetariano with dedicated ingredient categories and flexible selection rules
- add a tailored ingredient picker UI that enforces pricing, minimum selections, and real-time extra cost feedback

## Testing
- Not run (Gradle wrapper not present in repository)


------
https://chatgpt.com/codex/tasks/task_b_68dedf94b4b0832b8e186878c7313671