### PR TITLE
Fix material import for cart screen app bar

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf


### PR DESCRIPTION
## Summary
- add the missing Material 3 TopAppBar import in MainActivity so the cart screen compiles

## Testing
- Unable to run `./gradlew :app:compileDebugKotlin` because the Gradle wrapper script is not present in the repository


------
https://chatgpt.com/codex/tasks/task_b_68e41b4f3c84832b8ac25443ba2fa82a