### PR TITLE
Fix LazyColumn block closure in ProductListScreen

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -438,6 +438,7 @@ fun ProductListScreen(
                     }
                 }
             }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add the missing closing brace to the ProductListScreen LazyColumn so the file parses correctly

## Testing
- not run (Gradle wrapper script not present in repository)


------
https://chatgpt.com/codex/tasks/task_b_68e425d744b0832bb849f627b80250a8