### PR TITLE
Fix ingredient selection label interpolation

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -615,8 +615,10 @@ fun IngredientSelectorDialog(
                                         style = MaterialTheme.typography.bodySmall
                                     )
                                     if (usesFlexibleSelection) {
+                                        val selectionStatus = "${includedSelected}/${category.includedCount} " +
+                                            "incluido${if (category.includedCount != 1) "s" else ""}"
                                         Text(
-                                            text = "${includedSelected}/${category.includedCount} incluido${if (category.includedCount != 1) "s" else ""}",
+                                            text = selectionStatus,
                                             style = MaterialTheme.typography.bodySmall,
                                             color = MaterialTheme.colorScheme.primary
                                         )
@@ -747,8 +749,10 @@ private fun SushipletoVegetarianoIngredientContent(
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(text = "Base", fontWeight = FontWeight.SemiBold)
             Text(text = category.description, style = MaterialTheme.typography.bodySmall)
+            val baseSelectionStatus = "${includedSelected}/${category.includedCount} " +
+                "incluida${if (category.includedCount != 1) "s" else ""}"
             Text(
-                text = "${includedSelected}/${category.includedCount} incluida${if (category.includedCount != 1) "s" else ""}",
+                text = baseSelectionStatus,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary
             )


### PR DESCRIPTION
## Summary
- refactor the ingredient selection labels to build the text outside of the Text composable
- avoid multiline string interpolation that broke compilation for MainActivity

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68e5000fbb20832b88663deda2e75203