### PR TITLE
Add Ethna branding to catalog top bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.ui:ui-text-google-fonts")
     debugImplementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.navigation:navigation-compose:2.8.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")

--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -61,6 +62,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.googlefonts.Font
+import androidx.compose.ui.text.googlefonts.FontFamily
+import androidx.compose.ui.text.googlefonts.GoogleFont
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -334,6 +338,23 @@ fun ProductListScreen(
     onProductClick: (Product) -> Unit,
     onCartClick: () -> Unit
 ) {
+    val googleFontProvider = remember {
+        GoogleFont.Provider(
+            providerAuthority = "com.google.android.gms.fonts",
+            providerPackage = "com.google.android.gms",
+            certificates = R.array.com_google_android_gms_fonts_certs
+        )
+    }
+    val ethnaGoogleFont = remember { GoogleFont("Ethna") }
+    val ethnaFontFamily = remember {
+        FontFamily(
+            Font(
+                googleFont = ethnaGoogleFont,
+                fontProvider = googleFontProvider,
+                weight = FontWeight.Bold
+            )
+        )
+    }
     val sushipleto = products.firstOrNull { it.id == "sushipleto" }
     val sushipletoVegetariano = products.firstOrNull { it.id == "sushipleto_vegetariano" }
     val hasCombinedSushipleto = sushipleto != null && sushipletoVegetariano != null
@@ -368,11 +389,24 @@ fun ProductListScreen(
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
-                    Text(
-                        text = "ArmaTuHandroll",
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                            contentDescription = null,
+                            modifier = Modifier.size(32.dp)
+                        )
+                        Text(
+                            text = "Arma Tu Handroll",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontFamily = ethnaFontFamily,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
                 },
                 actions = {
                     IconButton(onClick = onCartClick) {

--- a/app/src/main/res/values/font_certs.xml
+++ b/app/src/main/res/values/font_certs.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <array name="com_google_android_gms_fonts_certs">
+        <item>@array/com_google_android_gms_fonts_certs_dev</item>
+        <item>@array/com_google_android_gms_fonts_certs_prod</item>
+    </array>
+    <array name="com_google_android_gms_fonts_certs_dev">
+        <item>
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArK/9na9Dk8Bww9Kw
+            XCO7DzicV30++NPBnZiybRYpHoXvq4p/0cYWE6jGn1ecNhqc7iiR3W83R7jo/
+            xm0Yo7XkzERKd8xRjqdsfCKvMrgQye+KpKjPlFv6OLj8yIvuP12ugH0/OKH64
+            pUoc05H5gJd27V9pNBK3ytC2aR6Ucx0DQ7zWPOYAZQyxu0Ydc0Vy/2Yg0XqC
+            ZDT9bd8QyPzzmx52PqU1BeG0unSC+cd7Upf4lT8o3g+fgFhVJXkjlzsSjh6x
+            Z1W+UZ1LvrCgEd59sFI2MzFxLpy0X58F3RrgPf63eNbUsVTKqlRW6KDWB3ob
+            VZpWTRbVvB6Yr3W9nCZP5zDB5wIDAQAB
+        </item>
+    </array>
+    <array name="com_google_android_gms_fonts_certs_prod">
+        <item>
+            MIIEQzCCAyugAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMHQxCzAJ
+            BgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3Vu
+            dGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5k
+            cm9pZDEYMBYGA1UEAxMPR29vZ2xlIFRydXN0IE1DQTAgFw0wODA4MjEyMzEz
+            MThaGA8yMjk2MDUxMTIzMTMxOFowdDELMAkGA1UEBhMCVVMxEzARBgNVBAgT
+            CkNhbGlmb3JuaWExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxFDASBgNVBAoT
+            C0dvb2dsZSBJbmMuMRAwDgYDVQQLEwdBbmRyb2lkMRgwFgYDVQQDEw9Hb29n
+            bGUgVHJ1c3QgTUNBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+            uU+tk4E1G6K/vn4GNzcRCjSc5MiNmiRC6L0n0RduCMsZ/HXXIQK5vPQn1vZ+
+            9O7GQUiRy4yuRgA3eV2pA/a6T3Hc6iNWJ5sv0N8vZimGvzznCqX4h1RRa1xN
+            I6sG4i0Kk3fX0sPAC9Bl4zphm0XrF5v9pC3BofU8QxF6G7KSn1k0GP7h/3pZJ
+            IFiHHP1dAJuY1FwlO2X0x+hnchlYV8oPZxC25f6/sOlne342XQI3/OQvPsvE
+            z8/rac0cJ8hGmrHkBD5pT5C5iVguI/3eYkP6MELyhlHLLJoPLD114F8bGZ4H
+            7pNQ7XJd0wC0hC5v1ZsEmM9QWf9eK6ujrQIDAQAB
+        </item>
+    </array>
+</resources>


### PR DESCRIPTION
## Summary
- load the Ethna Google Font and certificates so the catalog title can use it in bold
- restyle the catalog top bar to include the logo next to the renamed “Arma Tu Handroll” title and tint it with the primary color
- add the compose google fonts dependency to resolve the downloadable font family

## Testing
- ⚠️ `./gradlew -p /workspace/apphandroll test` *(fails: ./gradlew: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68e506205fe0832b887bf3f581bd47a0