### PR TITLE
Fix FontFamily import for Material3 Text

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -61,9 +61,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.googlefonts.Font
-import androidx.compose.ui.text.googlefonts.FontFamily
 import androidx.compose.ui.text.googlefonts.GoogleFont
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- replace the incorrect Google Fonts FontFamily import with the standard compose FontFamily
- ensure MainActivity uses the Material 3 Text component without FontFamily resolution issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e508568fa8832bafa5d97dc9444db6