### PR TITLE
Provide launcher icon resources and update references

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -370,7 +370,7 @@ fun ProductListScreen(
                 title = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Image(
-                            painter = painterResource(id = R.mipmap.ic_launcher_foreground),
+                            painter = painterResource(id = R.drawable.ic_launcher_foreground),
                             contentDescription = null,
                             modifier = Modifier.size(30.dp)
                         )

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M54,18c19.88,0 36,16.12 36,36s-16.12,36 -36,36 -36,-16.12 -36,-36 16.12,-36 36,-36z" />
+    <path
+        android:fillColor="#FF1E88E5"
+        android:pathData="M38,36 L54,78 70,36 C62,32 46,32 38,36z" />
+    <path
+        android:fillColor="#FF4CAF50"
+        android:pathData="M44,40 C48,36 60,36 64,40 L54,66z" />
+    <path
+        android:fillColor="#FFFF6F61"
+        android:pathData="M54,44a8,8 0 1,1 -0.01,0z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
## Summary
- add a vector-based launcher foreground drawable for the app icon
- point adaptive icon definitions to the drawable resource
- update the catalog toolbar image to load the drawable resource

## Testing
- not run (gradle wrapper script is missing in the repository)

------
https://chatgpt.com/codex/tasks/task_b_68e549ab1398832bb15c66c043d6cc9e