### PR TITLE
Ensure price formatting uses Chilean locale

### DIFF
--- a/app/src/main/java/com/example/apphandroll/PriceFormatter.kt
+++ b/app/src/main/java/com/example/apphandroll/PriceFormatter.kt
@@ -3,7 +3,17 @@ package com.example.apphandroll
 import java.text.NumberFormat
 import java.util.Locale
 
+private val chileanLocale = Locale("es", "CL")
+
+private val priceFormatter: ThreadLocal<NumberFormat> = ThreadLocal.withInitial {
+    NumberFormat.getIntegerInstance(chileanLocale).apply {
+        isGroupingUsed = true
+        maximumFractionDigits = 0
+    }
+}
+
 fun formatPrice(value: Int): String {
-    val formatter = NumberFormat.getIntegerInstance(Locale.getDefault())
+    require(value >= 0) { "Price cannot be negative" }
+    val formatter = priceFormatter.get()
     return "${'$'}${formatter.format(value)}"
 }

--- a/app/src/test/java/com/example/apphandroll/PriceFormatterTest.kt
+++ b/app/src/test/java/com/example/apphandroll/PriceFormatterTest.kt
@@ -1,0 +1,21 @@
+package com.example.apphandroll
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PriceFormatterTest {
+    @Test
+    fun `formats values using Chilean thousands separator`() {
+        val formatted = formatPrice(3_500)
+
+        assertEquals("$3.500", formatted)
+    }
+
+    @Test
+    fun `throws when formatting negative values`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            formatPrice(-1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure price formatting always uses the Chilean locale with grouping and guards against negative values
- add unit tests that verify the formatted output and negative value handling

## Testing
- gradle test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e54e054364832b8db7090590b586c5