### PR TITLE
Fix Compose resource references in ProductListScreen

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -413,7 +413,7 @@ fun ProductListScreen(
                 title = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Image(
-                            painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                            painter = painterResource(id = R.mipmap.ath),
                             contentDescription = null,
                             modifier = Modifier.size(30.dp)
                         )


### PR DESCRIPTION
## Summary
- replace the broken launcher drawable reference in the product list toolbar image with the existing mipmap resource
- keep the toolbar image parameters intact to preserve layout and behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e67fd409d0832b85f8617e0363b52b