### PR TITLE
Fix top app bar logo to use drawable resource

### DIFF
--- a/app/src/main/java/com/example/apphandroll/MainActivity.kt
+++ b/app/src/main/java/com/example/apphandroll/MainActivity.kt
@@ -413,7 +413,7 @@ fun ProductListScreen(
                 title = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Image(
-                            painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                            painter = painterResource(id = R.drawable.ath),
                             contentDescription = null,
                             modifier = Modifier.size(30.dp)
                         )


### PR DESCRIPTION
## Summary
- update the top app bar logo to load the drawable `ath` resource instead of the mipmap logo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e6926ed79c832bb444f18dd1e65593